### PR TITLE
Update internal CI config to skip running build/tests for a doc-only …

### DIFF
--- a/documents/high_level_overview.md
+++ b/documents/high_level_overview.md
@@ -2,7 +2,7 @@
 
 <!--* freshness: {
   owner: 'hongm'
-  reviewed: '2020-03-31'
+  reviewed: '2020-04-26'
 } *-->
 
 <!-- TOC -->


### PR DESCRIPTION
### Description

In this pull request, the modification made to the `high_level_overview.md` file is updating the review date from '2020-03-31' to '2020-04-26' for freshness tracking.

Changes:
- Update the review date in the freshness metadata from '2020-03-31' to '2020-04-26'.